### PR TITLE
Use bcrypt for password comparison in loginManager

### DIFF
--- a/swp391-server/src/app/controllers/auth.controllers.js
+++ b/swp391-server/src/app/controllers/auth.controllers.js
@@ -99,9 +99,10 @@ exports.loginManager = async (req, res) => {
       return res.status(401).json({ message: "Invalid username or password" });
     }
 
-    // So sánh password plain text (KHÔNG AN TOÀN, chỉ dùng để test/demo)
-    if (password !== user.password) {
-      console.log("Password mismatch");
+    // So sánh password đã hash
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      console.log("Password mismatch", password, user.password);
       return res.status(401).json({ message: "Invalid username or password" });
     }
 


### PR DESCRIPTION
Replaces insecure plain text password comparison with bcrypt hash comparison in the loginManager controller. This improves authentication security by ensuring passwords are properly validated against their hashed values.