### PR TITLE
Standardize route and param naming for surveys and courses

### DIFF
--- a/swp391-server/src/app/controllers/survey.controller.js
+++ b/swp391-server/src/app/controllers/survey.controller.js
@@ -22,7 +22,7 @@ exports.findSurveyByType = async (req, res) => {
 };
 
 exports.findSurveyBySurveyId = async (req, res) => {
-    const survey_id = req.params.surveyId;
+    const survey_id = req.params.survey_id;
     try {
         const survey = await surveyModel.findSurveyBySurveyID(survey_id);
         res.json(survey);
@@ -68,7 +68,7 @@ exports.submitSurvey = async (req, res) => {
 };
 
 exports.getSurveyHistoryByMember = async (req, res) => {
-    const user_id = req.params.memberId;
+    const user_id = req.params.member_id;
 
     // Validate input
     if (!user_id) {

--- a/swp391-server/src/routes/course.routes.js
+++ b/swp391-server/src/routes/course.routes.js
@@ -9,5 +9,5 @@ router.get('/enroll-course/:member_id/:course_id/:enroll_version', courseControl
 router.post('/submit-mooc-course', courseController.submitCourse)
 router.get('/check-enrollment-course/:member_id/:course_id/:enroll_version', courseController.checkEnrollmentCourse)
 // router.get('/get-course-by-course_id-and-version/:course_id/:version', courseController.getCourseByCourseIdAndVersion)
-router.get('/get-all-survey-follow-course-enrollment-by-member-id/:member_id', courseController.getAllCourseFollowSurveyEnrollmentByMemberId)
+router.get('/get-all-course-follow-course-enrollment-by-member-id/:member_id', courseController.getAllCourseFollowSurveyEnrollmentByMemberId)
 module.exports = router

--- a/swp391-server/src/routes/survey.routes.js
+++ b/swp391-server/src/routes/survey.routes.js
@@ -4,8 +4,8 @@ const survey = require("../app/controllers/survey.controller");
 
 router.get("/view-survey", survey.viewSurvey);
 router.get("/type-survey/:type", survey.findSurveyByType);
-router.get("/survey-by-id/:surveyId", survey.findSurveyBySurveyId);
+router.get("/survey-by-id/:survey_id", survey.findSurveyBySurveyId);
 router.post("/submit-survey", survey.submitSurvey);
-router.get("/survey-history/:memberId", survey.getSurveyHistoryByMember);
+router.get("/survey-history/:member_id", survey.getSurveyHistoryByMember);
 router.get("/get-all-survey-follow-survey-enrollment-by-member-id/:member_id", survey.getAllSurveyFollowSurveyEnrollmentByMemberId)
 module.exports = router;


### PR DESCRIPTION
Updated route parameter names from camelCase to snake_case in survey and course routes and controllers for consistency. Fixed a route name typo in course.routes.js to accurately reflect its purpose.