### PR TITLE
Refine consultant free time query logic

### DIFF
--- a/swp391-server/src/app/models/consultation.model.js
+++ b/swp391-server/src/app/models/consultation.model.js
@@ -65,17 +65,27 @@ WHERE appointment_id = ?`, [appointment_id]);
 }
 
 const getConsultantFreeTime = async (appointment_date, appointment_time) => {
-    const [rows] = await db.execute(`SELECT u.user_id, COUNT(CASE 
-    WHEN a.appointment_date = ? AND a.appointment_time = ? THEN a.appointment_id 
+    const [rows] = await db.execute(`SELECT 
+    u.user_id, 
+    COUNT(CASE 
+        WHEN a.appointment_date = ? 
+            AND a.appointment_time = ? 
+            AND (a.status = 'pending' OR a.status IS NULL)
+        THEN a.appointment_id 
     END) AS countByTime,
-    COUNT(CASE
-    	WHEN a.appointment_date = ? THEN a.appointment_id
+
+    COUNT(CASE 
+        WHEN a.appointment_date = ? 
+            AND (a.status = 'pending' OR a.status IS NULL)
+        THEN a.appointment_id 
     END) AS countByDate
+
 FROM Users u
 LEFT JOIN Appointment a ON a.consultant_id = u.user_id
-WHERE u.role = 'consultant' AND a.is_active = 1
+WHERE u.role = 'consultant' 
+  AND (a.is_active = 1 OR a.is_active IS NULL)
 GROUP BY u.user_id
-ORDER BY countByTime , countByDate;`, [appointment_date, appointment_time, appointment_date])
+ORDER BY countByTime, countByDate;`, [appointment_date, appointment_time, appointment_date])
     console.log(rows[0])
     return rows[0];
 }


### PR DESCRIPTION
Updated the SQL query in getConsultantFreeTime to consider only appointments with 'pending' or NULL status when counting, and to include consultants with no appointments by allowing a.is_active to be NULL. This improves accuracy in determining consultant availability.