### PR TITLE
Fix navigation and course completion status logic

### DIFF
--- a/swp391-client/src/components/Chatbot/Chatbot.jsx
+++ b/swp391-client/src/components/Chatbot/Chatbot.jsx
@@ -430,7 +430,9 @@ CÂU HỎI NGƯỜI DÙNG: `;
                     navigate(path + search);
                   } else {
                     // Điều hướng bình thường
-                    navigate(path + search);
+                    navigate();
+
+
                   }
                 } else {
                   // External link - mở tab mới

--- a/swp391-client/src/pages/Courses/CourseDetail.jsx
+++ b/swp391-client/src/pages/Courses/CourseDetail.jsx
@@ -59,7 +59,7 @@ function CourseDetail() {
             );
             console.log('du lieu response:', response)
             setIsEnrolled(response.data.isEnrolled || false);
-            setIsCompleted(response.data.status || false);
+            setIsCompleted(response.data.status === 'completed' || false);
 
         } catch (err) {
             console.error("Enrollment check error:", err);


### PR DESCRIPTION
Updated Chatbot navigation to use default navigation when no path is provided. Fixed CourseDetail to correctly set course completion status only when the status is 'completed'.